### PR TITLE
Fix improper vectorization in PyTorch implementation.

### DIFF
--- a/src/pytorch/quantum_activations.py
+++ b/src/pytorch/quantum_activations.py
@@ -59,8 +59,9 @@ def torch_quantum_relu(x: torch.Tensor, modified: bool = USE_M_QRELU) -> torch.T
     Returns:
             The transformed x (torch.Tensor) via the QReLU or m-QReLU.
     """
-    if torch.any(x <= 0):
-        second_coefficient = SECOND_COEFFICIENT_M_QRELU_PYTORCH if modified else SECOND_COEFFICIENT_QRELU_PYTORCH
-        x = FIRST_COEFFICIENT_PYTORCH * x - second_coefficient * x
-
-    return x
+    second_coefficient = SECOND_COEFFICIENT_M_QRELU_PYTORCH if modified else SECOND_COEFFICIENT_QRELU_PYTORCH
+    return torch.where(
+            x <= 0,
+            FIRST_COEFFICIENT_PYTORCH * x - second_coefficient * x,
+            x,
+    )


### PR DESCRIPTION
Thank you for creating this reference implementation for QReLU!

I noticed while going through the code that it seems like the implementation for PyTorch doesn't seem to be working as expected.

Currently, if _all_ values of `x` are positive, then it does nothing.  This is appropriate, but an exceedingly rare occurrence, especially because all values of `x` across all batches need to be positive.

If, on the other hand, there is a single negative value in the tensor, then _all_ values for `x` are multiplied by the coefficients.

The change that I provided behaves the same as your vectorized implementation for tensorflow / keras and only applies the coefficients to negative values of x.